### PR TITLE
Enum armed

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ After upgrade the addon the pages must be reloaded before the new attributes are
 
 ## Release notes ##
 
+0.1.1
+ * Made Armed property into an enum to make it easier to use in rules
+ * In 0.1.0 you had to type in "locked" or "unlocked" into the rule
+
 0.1.0
  * Initial release for version that has access codes built in
  * During config, enter the access code you will use

--- a/manifest.json
+++ b/manifest.json
@@ -108,5 +108,5 @@
     }
   },
   "short_name": "Konnected",
-  "version": "0.1.0"
+  "version": "0.1.1"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "konnected-adapter",
   "display_name": "Konnected Adapter",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Konnected addon for WebThingsIO Gateway",
   "author": "wfahle",
   "main": "main.py",

--- a/pkg/konnected_property.py
+++ b/pkg/konnected_property.py
@@ -110,6 +110,11 @@ class KIArmedProperty(KonnectedProperty):
                                        'type': 'string',
                                        '@type': 'LockedProperty',
                                        'readOnly': True
+                                       'enum': [
+                                           'locked',
+                                           'unlocked',
+                                           'unknown'
+                                       ]
                                    })
         self.ki = ki
 

--- a/pkg/konnected_property.py
+++ b/pkg/konnected_property.py
@@ -109,7 +109,7 @@ class KIArmedProperty(KonnectedProperty):
                                        'label': 'Armed',
                                        'type': 'string',
                                        '@type': 'LockedProperty',
-                                       'readOnly': True
+                                       'readOnly': True,
                                        'enum': [
                                            'locked',
                                            'unlocked',


### PR DESCRIPTION
Turned Armed property into enum of "locked", "unlocked", or "unknown" for ease of use in Rules